### PR TITLE
Don't require AWS credentials to be set explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ For detailed information on what plugin hooks are and how they work, please refe
 
 For detailed information on how configuration of plugins works, please refer to the [Plugin Documentation][1].
 
-### accessKeyId (`required`)
+### accessKeyId
 
-The AWS access key for the user that has the ability to upload to the `bucket`.
+The AWS access key for the user that has the ability to upload to the `bucket`. If this is left undefined, the normal [AWS SDK credential resolution](https://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials) will take place.
 
 *Default:* `undefined`
 
-### secretAccessKey (`required`)
+### secretAccessKey
 
-The AWS secret for the user that has the ability to upload to the `bucket`.
+The AWS secret for the user that has the ability to upload to the `bucket`. This must be defined when `accessKeyId` is defined.
 
 *Default:* `undefined`
 

--- a/lib/cloudfront.js
+++ b/lib/cloudfront.js
@@ -5,12 +5,20 @@ var uuid       = require('uuid');
 module.exports = CoreObject.extend({
   init: function(options) {
     this._plugin = options.plugin;
+
     var AWS = require('aws-sdk');
-    this._client = this._plugin.readConfig('cloudfrontClient') || new AWS.CloudFront({
-      accessKeyId: this._plugin.readConfig('accessKeyId'),
-      secretAccessKey: this._plugin.readConfig('secretAccessKey'),
+    const accessKeyId = this._plugin.readConfig('accessKeyId');
+    const secretAccessKey = this._plugin.readConfig('secretAccessKey');
+    var awsOptions = {
       region: this._plugin.readConfig('region')
-    });
+    };
+
+    if (accessKeyId && secretAccessKey) {
+      awsOptions.accessKeyId = accessKeyId;
+      awsOptions.secretAccessKey = secretAccessKey;
+    }
+
+    this._client = this._plugin.readConfig('cloudfrontClient') || new AWS.CloudFront(awsOptions);
   },
 
   invalidate: function(options) {

--- a/tests/unit/lib/cloudfront-nodetest.js
+++ b/tests/unit/lib/cloudfront-nodetest.js
@@ -1,9 +1,13 @@
 var assert = require('ember-cli/tests/helpers/assert');
 
+
 describe('cloudfront', function() {
   var CloudFront, mockUi, cloudfrontClient, plugin, subject;
 
   before(function() {
+    process.env['AWS_ACCESS_KEY_ID'] = 'set_via_env_var';
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'set_via_env_var';
+
     CloudFront = require('../../../lib/cloudfront');
   });
 
@@ -32,6 +36,55 @@ describe('cloudfront', function() {
       objectPaths: ['/index.html'],
       distribution: 'ABCDEFG'
     };
+  });
+
+  describe('#init', function() {
+    context('with a custom CloudFront client', function() {
+      it('uses the custom client', function() {
+        assert.equal(cloudfrontClient, subject._client);
+      })
+    });
+
+    context('using the aws-sdk CloudFront client', function() {
+      beforeEach(function() {
+        awsClient = {};
+        plugin.readConfig = function(propertyName) {};
+        subject = new CloudFront({plugin: plugin});
+      });
+
+      it('uses the AWS client', function() {
+        var AWS = require('aws-sdk');
+        assert.ok(subject._client instanceof AWS.CloudFront);
+      });
+
+      context('with credentials in plugin config', function() {
+        beforeEach(function() {
+          plugin.readConfig = function(propertyName) {
+            if(propertyName === 'accessKeyId' || propertyName === 'secretAccessKey') {
+              return 'set_via_config';
+            }
+          };
+          subject = new CloudFront({plugin: plugin});
+        });
+
+        it('uses the configured credentials', function() {
+          assert.equal('set_via_config', subject._client.config.credentials.accessKeyId);
+          assert.equal('set_via_config', subject._client.config.credentials.secretAccessKey);
+        });
+      });
+
+      context('with no credentials in the plugin config', function() {
+        beforeEach(function() {
+          plugin.readConfig = function(propertyName) {};
+          subject = new CloudFront({plugin: plugin});
+        });
+
+        it('falls back to default AWS credential resolution', function() {
+          assert.equal('set_via_env_var', subject._client.config.credentials.accessKeyId);
+          assert.equal('set_via_env_var', subject._client.config.credentials.secretAccessKey);
+        });
+      });
+    });
   });
 
   describe('#invalidate', function() {


### PR DESCRIPTION
This matches the behavior of ember-cli-deploy-s3, falling back to the default credential resolution behavior of aws-sdk if no credentials are provided. The advantage here is that keys can be read automatically from ~/.aws/credentials if it exists, avoiding app-specific configuration.

If credentials are provided in the deploy environment, they will still take precedence.