### PR TITLE
Remove accessKeyId & secretAccessKey from requiredConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
           return context.cloudfrontClient; // if you want to provide your own CloudFront client to be used instead of one from aws-sdk
         }
       },
-      requiredConfig: ['accessKeyId', 'secretAccessKey', 'distribution', 'region'],
+      requiredConfig: ['distribution', 'region'],
 
       didActivate: function(context) {
         var self            = this;


### PR DESCRIPTION
This was needed for me to get this plugin to work with aws cli credentials. I think it may have been left out from #1.