### PR TITLE
Add `rsvp` as dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "core-object": "^3.1.0",
     "ember-cli-babel": "^5.2.4",
     "ember-cli-deploy-plugin": "~0.2.9",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "rsvp": "^3.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",


### PR DESCRIPTION
Commit 3bc2344dbe2ea7b07fe270e5c5314bf65406775b introduced `rsvp` as a
dependency but didn't declare it in package.json

Without this PR I get the following error in a project that uses `ember-cli-deploy-cloudfront`

```
npm test

> ticketbooth@0.0.0 test /home/ewan/projects/ticketsolve/ticketsolve/ember
> ember test --reporter dot

Cannot find module 'rsvp'
Error: Cannot find module 'rsvp'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/ewan/projects/ticketsolve/ticketsolve/ember/node_modules/ember-cli-deploy-cloudfront/index.js:4:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
```