### PR TITLE
Add support for AWS Session Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ The AWS secret for the user that has the ability to upload to the `bucket`. This
 
 *Default:* `undefined`
 
+### sessionToken
+
+The AWS session token for the user that has the ability to manage the CloudFront distribution. This may be required if you are using the [AWS Security Token Service][6].
+This requires both `accessKeyId` and `secretAccessKey` to be defined.
+
+*Default:* `undefined`
+
 ### distribution (`required`)
 
 The CloudFront distribution ID that should be invalidated.

--- a/lib/cloudfront.js
+++ b/lib/cloudfront.js
@@ -16,6 +16,10 @@ module.exports = CoreObject.extend({
       region: this._plugin.readConfig('region')
     };
 
+    if (this._plugin.readConfig('sessionToken')) {
+      awsOptions.sessionToken = this._plugin.readConfig('sessionToken');
+    }
+
     if (accessKeyId && secretAccessKey) {
       awsOptions.accessKeyId = accessKeyId;
       awsOptions.secretAccessKey = secretAccessKey;


### PR DESCRIPTION
Related to the change in the `ember-cli-deploy-s3` plugin; if your deployment requires temporary credentials the `sessionToken` param is required.

See https://github.com/ember-cli-deploy/ember-cli-deploy-s3/commit/667ebefd0ba36ece413200ae8d0a71e418dcd4f7