### PR TITLE
Add tests for custom objectPaths

### DIFF
--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,0 +1,85 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
+var assert = require('./helpers/assert');
+var plugin = require('../index');
+var BasePlugin = require('ember-cli-deploy-plugin');
+
+describe('ember-cli-dpeloy-cloudfront plugin', function() {
+  var pluginInstance, invalidateAssertions;
+  var invalidateMock = function(options) {
+    invalidateAssertions.forEach(function(customAssert) {
+      customAssert(options);
+    });
+    return Promise.resolve('invalidation_id');
+  };
+
+  beforeEach(function() {
+    var mockUi = {
+      messages: [],
+      verbose: true,
+      startProgress: function() { },
+      write: function() { },
+      writeLine: function(message) {
+        this.messages.push(message);
+      },
+      writeError: function(message) {
+        this.messages.push(message);
+      },
+      writeDeprecateLine: function(message) {
+        this.messages.push(message);
+      },
+      writeWarnLine: function(message) {
+        this.messages.push(message);
+      }
+    };
+    invalidateAssertions = [];
+    pluginInstance = plugin.createDeployPlugin({
+      name: 'ember-cli-deploy-cloudfront-test'
+    });
+    var context = {
+      ui: mockUi,
+      config: {
+        'ember-cli-deploy-cloudfront-test': {
+          distribution: 'nope',
+          invalidationClient: {
+            invalidate: invalidateMock
+          }
+        }
+      }
+    };
+    pluginInstance.beforeHook(context);
+    pluginInstance.configure();
+  });
+
+  it('returns a plugin instance', function() {
+    assert.ok(pluginInstance instanceof BasePlugin);
+  });
+
+  describe('objectPaths option', function() {
+    it('has a default value of objects to invalidate', function() {
+      invalidateAssertions.push(function(options) {
+        assert.deepEqual(options.objectPaths, ['/index.html']);
+      });
+      pluginInstance.didActivate();
+    });
+
+    it('allows to customize the objects to invalidate', function() {
+      pluginInstance.pluginConfig.objectPaths = ['/yep.html'];
+      invalidateAssertions.push(function(options) {
+        assert.deepEqual(options.objectPaths, ['/yep.html']);
+      });
+      pluginInstance.didActivate();
+    });
+
+    it('allows to use a function for objectPaths', function() {
+      pluginInstance.pluginConfig.objectPaths = function(/*config, context, configHelper*/) {
+        return ['/dynamic_filename.html'];
+      };
+      invalidateAssertions.push(function(options) {
+        assert.deepEqual(options.objectPaths, ['/dynamic_filename.html']);
+      });
+      pluginInstance.didActivate();
+    });
+  });
+});
+


### PR DESCRIPTION
closes #67 

Well, have I got good news: the discussion in #67 and your favourite solution (using a function to customise a config property) is already a default feature in `ember-cli-deploy` 🎉 

I've just added some tests to make it more obvious to the following users (and at the same time kickstart the test suite for the plugin itself).

See http://ember-cli-deploy.com/docs/v1.0.x/configuration/#usage for the documentation and the associated code in `ember-cli-deploy-plugin` is https://github.com/ember-cli-deploy/ember-cli-deploy-plugin/blob/master/index.js#L68-L70.

