### PR TITLE
Added waitForInvalidation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ The client specified MUST implement a function called `createInvalidation`.
 
 *Default:* the default CloudFront library is `aws-sdk`
 
+### waitForInvalidation 
+
+If set to `true` the deployment will wait until AWS reports invalidation complete state. This ensures new version is available online after the pipeline is finished. This can be useful to know, for example before running further tests against deployed production. Note that it may take several minutes or more for the invalidation to fully complete, so only use this option if you *really* need to wait for the invalidation to complete. 
+
+*Default:* `false`
+
 ## Disable in Selected Environments
 
 If your application doesn't need CloudFront invalidation in an environment where you do need to run other activation hooks, it is possible to whitelist the plugins that you *do* want ember-cli-deploy to run. For an application using the ember-cli-deploy-aws-pack for example, the whitelist would look like this when excluding ember-cli-deploy-cloudfront:

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ module.exports = {
           self.log('preparing to create invalidation for CloudFront distribution `' + distribution + '`', { verbose: true });
 
           return cloudfront.invalidate(options)
-            .then(function() {
-              self.log('invalidation completed', { verbose: true });
+            .then(function(invalidationId) {
+              self.log('invalidation process finished for invalidation ' + invalidationId, { verbose: true });
             })
             .catch(self._errorMessage.bind(self));
         });

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ module.exports = {
         },
         cloudfrontClient: function(context) {
           return context.cloudfrontClient; // if you want to provide your own CloudFront client to be used instead of one from aws-sdk
-        }
+        },
+        waitForInvalidation: false,
       },
       requiredConfig: ['distribution', 'region'],
 
@@ -28,6 +29,7 @@ module.exports = {
 
         var distribution    = this.readConfig('distribution');
         var objectPaths     = this.readConfig('objectPaths');
+        var waitForInvalidation = this.readConfig('waitForInvalidation')
 
         var cloudfront = this.readConfig('invalidationClient') || new CloudFront({
           plugin: this
@@ -37,14 +39,15 @@ module.exports = {
         var distributionInvalidations = distributions.map(function(distribution) {
           var options = {
             objectPaths: objectPaths,
-            distribution: distribution
+            distribution: distribution,
+            waitForInvalidation: waitForInvalidation
           };
 
           self.log('preparing to create invalidation for CloudFront distribution `' + distribution + '`', { verbose: true });
 
           return cloudfront.invalidate(options)
-            .then(function(invalidation) {
-              self.log('created CloudFront invalidation `' + invalidation + '` ok', { verbose: true });
+            .then(function() {
+              self.log('invalidation completed', { verbose: true });
             })
             .catch(self._errorMessage.bind(self));
         });

--- a/lib/cloudfront.js
+++ b/lib/cloudfront.js
@@ -60,6 +60,7 @@ module.exports = CoreObject.extend({
         if (error) {
           reject(error);
         } else {
+          this._plugin.log('created CloudFront invalidation ' + data.Invalidation.Id + ' ok');
           if (options.waitForInvalidation) {
             var params = {
               DistributionId: distribution,
@@ -74,7 +75,6 @@ module.exports = CoreObject.extend({
               }
             }.bind(this));
           } else {
-            this._plugin.log('created CloudFront invalidation ' + data.Invalidation.Id + ' ok')
             resolve(data.Invalidation.Id);
           }
         }

--- a/lib/cloudfront.js
+++ b/lib/cloudfront.js
@@ -60,7 +60,23 @@ module.exports = CoreObject.extend({
         if (error) {
           reject(error);
         } else {
-          resolve(data.Invalidation.Id);
+          if (options.waitForInvalidation) {
+            var params = {
+              DistributionId: distribution,
+              Id: data.Invalidation.Id
+            };
+            this._plugin.log('waiting for invalidation ' + data.Invalidation.Id + ' to complete');
+            this._client.waitFor('invalidationCompleted', params, function(invalidationCompletedError) {
+              if (invalidationCompletedError) {
+                reject(invalidationCompletedError);
+              } else {
+                resolve(data.Invalidation.Id);
+              }
+            }.bind(this));
+          } else {
+            this._plugin.log('created CloudFront invalidation ' + data.Invalidation.Id + ' ok')
+            resolve(data.Invalidation.Id);
+          }
         }
       }.bind(this));
     }.bind(this));


### PR DESCRIPTION
This change gives us an option to wait for invalidation to complete before deploy pipeline is finished.

This is important to make sure the UI is available in the latest version when starting automated tests immediately after the deployment.